### PR TITLE
Add support for @throws

### DIFF
--- a/partials/method.handlebars
+++ b/partials/method.handlebars
@@ -90,20 +90,18 @@
       </div>
     {{/if}}
 
-    {{#if throws}}
-      <div class="return">
+    {{#throws}}
+      <div class="throws">
         <h4>Throws:</h4>
-        {{#each throws}}
-          <div>
-            {{#if type}}<span class="throws-type">{{#crossLink type}}{{/crossLink}}</span>{{/if}}
-            <span class="throws-description">{{{description}}}</span>
-          </div>
-        {{/each}}
+        <div class="throws-description">
+          {{#if type}} <span class="type">{{#crossLink type}}{{/crossLink}}</span>: {{/if}}
+          {{#if description}} {{{description}}} {{/if}}
+        </div>
       </div>
-    {{/if}}
+    {{/throws}}
 
     {{#if example}}
-        <h4>Example:</h4>
-        {{{example}}}
+      <h4>Example:</h4>
+      {{{example}}}
     {{/if}}
 </div>


### PR DESCRIPTION
Hi,

Today implementation does not seem to support @throws properly. @throws type & description are today ignored and only the section title is displayed. This proposes to fix it.

You can see [here](https://github.com/bmeurant/ember-array-contains-helper/blob/yuidocs/addon/helpers/array-contains.js#L56) an actual non working example (doc is not yet deployed though).

You can also see it in `ember-cli` comparing [source](https://github.com/ember-cli/ember-cli/blob/d8ba7dbaf77df0e7fe2daf1d153a1a5a60620143/lib/models/blueprint.js#L342) and [doc api](https://ember-cli.com/api/classes/Blueprint.html)
