### PR TITLE
Use https version YUI assets

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,4 +1,4 @@
 {
-    "yuiGridsUrl": "http://yui.yahooapis.com/3.8.0pr2/build/cssgrids/cssgrids-min.css",
-    "yuiSeedUrl": "http://yui.yahooapis.com/combo?3.8.0pr2/build/yui/yui-min.js"
+    "yuiGridsUrl": "https://cdnjs.cloudflare.com/ajax/libs/yui/3.18.0/cssgrids/cssgrids-min.css",
+    "yuiSeedUrl": "https://cdnjs.cloudflare.com/ajax/libs/yui/3.18.0/yui/yui-min.js"
 }


### PR DESCRIPTION
Since ember-cli.com served as a https website, old http based assets can not be loaded properly. This patch aims to use https based YUI assets from cloudflare CDN, and catch up the latest minor versions as well.